### PR TITLE
Add wrapping and word-break CSS for answer analysis content

### DIFF
--- a/kaoshibao-shortcuts.user.js
+++ b/kaoshibao-shortcuts.user.js
@@ -177,6 +177,9 @@
                 -webkit-line-clamp: 999 !important; line-clamp: 999 !important;
                 max-height: none !important; height: auto !important;
                 overflow: visible !important; text-overflow: clip !important;
+                white-space: normal !important;
+                word-break: break-word !important;
+                overflow-wrap: anywhere !important;
                 user-select: text !important;
             }
             .answer-analysis-row, .answer-analysis { -webkit-box-orient: vertical !important; }
@@ -185,6 +188,9 @@
             .answer-box-detail p, .answer-box-detail span {
                 color: #222 !important; opacity: 1 !important; filter: none !important;
                 -webkit-text-fill-color: #222 !important; user-select: text !important;
+                white-space: normal !important;
+                word-break: break-word !important;
+                overflow-wrap: anywhere !important;
             }
 
             [class*="blur"] { display: none !important; pointer-events: none !important; }


### PR DESCRIPTION
### Motivation
- Ensure analysis and detail text always wraps and breaks long words so that `keep-all`/`nowrap` page styles do not prevent automatic line breaks in the cleaned UI.

### Description
- In `applyCleanUI()` of `kaoshibao-shortcuts.user.js`, add `white-space: normal !important;`, `word-break: break-word !important;`, and `overflow-wrap: anywhere !important;` for `.answer-analysis`, `.answer-analysis-row`, `.answer-detail`, `.deepseek-row .content`, and `.answer-box-detail p, .answer-box-detail span` to force wrapping and override site rules.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a42fbb8c832086ca00f150049e37)