### PR TITLE
Expand answer analysis rows on VIP unlock

### DIFF
--- a/kaoshibao-shortcuts.user.js
+++ b/kaoshibao-shortcuts.user.js
@@ -200,6 +200,15 @@
     function unlockVIP() {
         if (!userConfig.features.vipUnlock) return;
 
+        document.querySelectorAll('.answer-analysis-row.hide-height').forEach(element => {
+            element.classList.remove('hide-height');
+            if (!element.style) return;
+            element.style.maxHeight = '';
+            element.style.height = '';
+            element.style.overflow = '';
+            element.style.whiteSpace = '';
+        });
+
         // 移除 VIP 相关遮罩和按钮
         const selectorsToRemove = [
             '.vip-quanyi', '.vip-tips', '.vip-mask', '.open-vip-btn',


### PR DESCRIPTION
### Motivation
- Allow previously-collapsed VIP analysis content to fully expand when `unlockVIP()` runs by removing the `hide-height` class and any inline sizing/overflow restrictions while keeping existing MutationObserver behavior.

### Description
- Update `unlockVIP()` to query `.answer-analysis-row.hide-height`, call `element.classList.remove('hide-height')`, and clear inline `maxHeight`, `height`, `overflow`, and `whiteSpace` styles so analysis can wrap and expand.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a42f6d048320b0839ef4623a6ebf)