### PR TITLE
fix: 提升 AI 解析文字可读性，解决灰字与底色不易区分

### DIFF
--- a/kaoshibao-shortcuts.user.js
+++ b/kaoshibao-shortcuts.user.js
@@ -170,10 +170,11 @@
 
             .app-main { padding-top: 20px !important; }
 
-            /* 解锁解析内容样式 */
+            /* 解锁解析内容样式（提升对比度，避免灰字看不清） */
             .answer-analysis, .answer-analysis-row, .answer-detail {
-                color: #222 !important; opacity: 1 !important; filter: none !important;
-                text-shadow: none !important; -webkit-text-fill-color: #222 !important;
+                color: #111 !important; opacity: 1 !important; filter: none !important;
+                background-color: #fff !important;
+                text-shadow: none !important; -webkit-text-fill-color: #111 !important;
                 -webkit-line-clamp: 999 !important; line-clamp: 999 !important;
                 max-height: none !important; height: auto !important;
                 overflow: visible !important; text-overflow: clip !important;
@@ -184,10 +185,17 @@
             }
             .answer-analysis-row, .answer-analysis { -webkit-box-orient: vertical !important; }
 
+            .answer-analysis *, .answer-analysis-row *, .answer-detail * {
+                color: #111 !important;
+                opacity: 1 !important;
+                -webkit-text-fill-color: #111 !important;
+                text-shadow: none !important;
+            }
+
             .deepseek-row .content,
             .answer-box-detail p, .answer-box-detail span {
-                color: #222 !important; opacity: 1 !important; filter: none !important;
-                -webkit-text-fill-color: #222 !important; user-select: text !important;
+                color: #111 !important; opacity: 1 !important; filter: none !important;
+                -webkit-text-fill-color: #111 !important; user-select: text !important;
                 white-space: normal !important;
                 word-break: break-word !important;
                 overflow-wrap: anywhere !important;


### PR DESCRIPTION
### Motivation
- 用户反馈破解后的 AI 解析文字呈灰色，与背景底色对比不足，影响阅读与识别。

### Description
- 在 `kaoshibao-shortcuts.user.js` 注入样式中将解析区域主文本颜色从 `#222` 调整为更深的 `#111` 并补充 `background-color: #fff` 以避免背景混色导致发灰。 
- 新增 `.answer-analysis *`, `.answer-analysis-row *`, `.answer-detail *` 等后代选择器以强制覆盖内部子元素继承/重置导致的灰色样式。 
- 同步将 `.deepseek-row .content` 与 `.answer-box-detail` 等答案详情文本颜色改为 `#111`，并保持 `opacity: 1` 与移除文本阴影以提升可读性。

### Testing
- 运行语法检查 `node --check kaoshibao-shortcuts.user.js`，结果通过。 
- 使用 Playwright 脚本打开站点并生成页面截图，脚本运行成功并产出截图 artifact。 
- 变更仅涉及注入的 CSS，不修改快捷键或逻辑代码，未发现语法或运行时错误。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986058b0e2883208b583d00fc195dc9)